### PR TITLE
Install mezzanine dependencies. Resolve #5.

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,13 @@
 FROM python:3.5-onbuild
 MAINTAINER George Cushen
 
+# Install Mezzanine dependencies.
+RUN sed "s/^deb\ /deb-src /g" /etc/apt/sources.list >> /etc/apt/sources.list && \
+    DEBIAN_FRONTEND=noninteractive apt-get clean && apt-get update && \
+    apt-get install -y \
+        libjpeg-dev &&\
+    apt-get build-dep -y \
+        python-imaging
+
 # Add start script
 ADD ./start.sh /


### PR DESCRIPTION
See mezzanine/project_template/fabfile.py for mezzanine's dependencies.
Those are for Ubuntu though, and this project is based off Debian.
Furthermore several of them ship with the base python image.

**I haven't actually tested this patch or even tried this project, but this is what I do in my docker setup.**
