### PR TITLE
Add web/static to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.db
 __pycache__
 .DS_Store
+web/static/
+


### PR DESCRIPTION
In case you want to run locally, this keeps the `manage.py collectstatic` generated files out of the repo.
