### PR TITLE
Fixes #8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,41 +1,45 @@
 # Docker for Mezzanine CMS + REST API
+version: '2'
 
-# A microservice for the web app.
-web:
-  container_name: web
-  restart: always
-  build: ./web
-  expose:
-    - "8000"
-  links:
-    - postgres:postgres
-  volumes:
-    - ./web/static:/usr/src/app/static
-    - ./web/static/media:/usr/src/app/static/media
-  env_file: .env
-  command: /start.sh
+services:
+  # A microservice for the web app.
+  web:
+    container_name: web
+    restart: always
+    build: ./web
+    expose:
+      - "8000"
+    links:
+      - postgres:postgres
+    depends_on:
+      - postgres
+    volumes:
+      - ./web/static:/usr/src/app/static
+      - ./web/static/media:/usr/src/app/static/media
+    env_file: .env
+    command: /start.sh
 
-# A microservice for the web server.
-nginx:
-  container_name: nginx
-  restart: always
-  build: ./nginx/
-  ports:
-    - "80:80"
-  volumes:
-    - /www/static
-    - /www/static/media
-  volumes_from:
-    - web
-  links:
-    - web:web
+  # A microservice for the web server.
+  nginx:
+    container_name: nginx
+    restart: always
+    build: ./nginx
+    ports:
+      - "80:80"
+    volumes:
+      - /www/static
+      - /www/static/media
+    volumes_from:
+      - web
+    links:
+      - web:web
 
-# A microservice for the database.
-postgres:
-  container_name: postgres
-  restart: always
-  image: postgres:latest
-  ports:
-    - "5432:5432"
-  volumes:
-    - pgdata:/var/lib/postgresql/data/
+  # A microservice for the database.
+  postgres:
+    container_name: postgres
+    restart: always
+    image: postgres:latest
+    ports:
+      - "5432:5432"
+    #volumes:
+    #  - pgdata:/var/lib/postgresql/data/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -9,5 +9,9 @@ RUN sed "s/^deb\ /deb-src /g" /etc/apt/sources.list >> /etc/apt/sources.list && 
     apt-get build-dep -y \
         python-imaging
 
+ENV DOCKERIZE_VERSION v0.2.0
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
 # Add start script
 ADD ./start.sh /

--- a/web/start.sh
+++ b/web/start.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo "Waiting for postgres container to be available"
+dockerize -wait tcp://postgres:5432
+
 echo "Mezzanine microservice executing: createdb/migrate ..."
 python3 manage.py createdb --noinput
 


### PR DESCRIPTION
Adds dockerize to web container and uses it to wait for postgres container to be available before running the rest of the `start.sh` script in the web container.

Also, I have confirmed that the changes made by @ryneeverett in [pr #6](https://github.com/gcushen/mezzanine-api-docker/pull/6) do resolve the issue with the gallery!
